### PR TITLE
NDSInstrSet: Name PGM instruments

### DIFF
--- a/src/main/VGMColl.cpp
+++ b/src/main/VGMColl.cpp
@@ -161,6 +161,12 @@ SF2File *VGMColl::CreateSF2File() {
   return sf2file;
 }
 
+static std::string wstring_to_string(std::wstring str) {
+	char buf[256] = {};
+	wcstombs(buf, str.c_str(), sizeof(buf));
+	return std::string(buf);
+}
+
 bool VGMColl::MainDLSCreation(DLSFile &dls) {
   vector<VGMSamp *> finalSamps;
   //we have to collect the finalSampColls in case sampcolls is empty but there are multiple instrSets with
@@ -195,9 +201,8 @@ bool VGMColl::MainDLSCreation(DLSFile &dls) {
     for (size_t i = 0; i < nInstrs; i++) {
       VGMInstr *vgminstr = set->aInstrs[i];
       size_t nRgns = vgminstr->aRgns.size();
-      if (nRgns == 0)                                //do not write an instrument if it has no regions
-        continue;
-      DLSInstr *newInstr = dls.AddInstr(vgminstr->bank, vgminstr->instrNum);
+	  std::string name = wstring_to_string(vgminstr->name);
+      DLSInstr *newInstr = dls.AddInstr(vgminstr->bank, vgminstr->instrNum, name);
       for (uint32_t j = 0; j < nRgns; j++) {
         VGMRgn *rgn = vgminstr->aRgns[j];
         //				if (rgn->sampNum+1 > sampColl->samples.size())	//does thereferenced sample exist?

--- a/src/main/formats/NDSInstrSet.cpp
+++ b/src/main/formats/NDSInstrSet.cpp
@@ -69,25 +69,22 @@ bool NDSInstr::LoadInstr() {
       break;
     }
 
-    case 0x02:        //used in Mr. Driller "BANK_BGM" for some reason
-    case 0x03:
-    case 0x04:
-    case 0x05:
-      break;
+	case 0x02: {
+		/* PGM Tone */
+		uint8_t dutyCycle = GetByte(dwOffset) & 0x07;
+		std::wstring dutyCycles[8] = {
+			L"12.5%", L"25%", L"37.5%", L"50%", L"62.5%", L"75%", L"87.5%", L"0%"
+		};
+		name = L"NES Sq (" + dutyCycles[dutyCycle] + L")";
+		unLength = 10;
+		break;
+	}
+	case 0x03:
+		name = L"NES Noise";
+		unLength = 10;
+		break;
 
-    case 0x06:
-    case 0x07:
-    case 0x08:
-    case 0x09:
-    case 0x0A:
-    case 0x0B:
-    case 0x0C:
-    case 0x0D:
-    case 0x0E:
-    case 0x0F:
-      break;
-
-    //drumset
+	//drumset
     case 0x10:
     {
       name = L"Drumset";


### PR DESCRIPTION
We don't generate waveforms, but it's nice to know what settings and
duty cycles to use for instruments for e.g. an NES VST plugin.

Also include instrument names in VGMColl, and spit out instruments that
have no regions, because the name is still helpful.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] I have read the **CONTRIBUTING** document.
